### PR TITLE
Add support for security context on main container

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -34,6 +34,7 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -60,6 +61,7 @@ import org.springframework.util.StringUtils;
  * @author Chris Schaefer
  * @author Enrique Medina Montenegro
  * @author Ilayaperumal Gopinathan
+ * @author Chris Bono
  */
 public class AbstractKubernetesDeployer {
 
@@ -250,6 +252,12 @@ public class AbstractKubernetesDeployer {
 		if (hostNetwork) {
 			podSpec.withHostNetwork(true);
 		}
+
+		SecurityContext containerSecurityContext = this.deploymentPropertiesResolver.getContainerSecurityContext(deploymentProperties);
+		if (containerSecurityContext != null) {
+			container.setSecurityContext(containerSecurityContext);
+		}
+
 		podSpec.addToContainers(container);
 
 		podSpec.withRestartPolicy(this.deploymentPropertiesResolver.getRestartPolicy(deploymentProperties).name());

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -41,6 +41,8 @@ import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.SecretEnvSource;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
+import io.fabric8.kubernetes.api.model.SecurityContext;
+import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -432,6 +434,28 @@ class DeploymentPropertiesResolver {
 					deployerProperties.getPodSecurityContext().getSeccompProfile().getType());
 		}
 		return podSecurityContextBuilder.build();
+	}
+
+	SecurityContext getContainerSecurityContext(Map<String, String> kubernetesDeployerProperties) {
+		SecurityContext securityContext = null;
+
+		KubernetesDeployerProperties deployerProperties = bindProperties(kubernetesDeployerProperties,
+				this.propertyPrefix + ".containerSecurityContext", "containerSecurityContext");
+
+		if (deployerProperties.getContainerSecurityContext() != null) {
+			securityContext = buildContainerSecurityContext(deployerProperties);
+
+		} else if (this.properties.getContainerSecurityContext() != null ) {
+			securityContext = buildContainerSecurityContext(this.properties);
+		}
+		return securityContext;
+	}
+
+	private SecurityContext buildContainerSecurityContext(KubernetesDeployerProperties deployerProperties) {
+		return new SecurityContextBuilder()
+				.withAllowPrivilegeEscalation(deployerProperties.getContainerSecurityContext().isAllowPrivilegeEscalation())
+				.withReadOnlyRootFilesystem(deployerProperties.getContainerSecurityContext().isReadOnlyRootFilesystem())
+				.build();
 	}
 
 	Affinity getAffinityRules(Map<String, String> kubernetesDeployerProperties) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -38,6 +38,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * @author Chris Schaefer
  * @author David Turanski
  * @author Enrique Medina Montenegro
+ * @author Chris Bono
  */
 @ConfigurationProperties(prefix = KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX)
 public class KubernetesDeployerProperties {
@@ -342,6 +343,8 @@ public class KubernetesDeployerProperties {
 
 		private Long[] supplementalGroups;
 
+		private SeccompProfile seccompProfile;
+
 		public void setRunAsUser(Long runAsUser) {
 			this.runAsUser = runAsUser;
 		}
@@ -364,6 +367,46 @@ public class KubernetesDeployerProperties {
 
 		public Long[] getSupplementalGroups(){
 			return supplementalGroups;
+		}
+
+		public SeccompProfile getSeccompProfile() {
+			return seccompProfile;
+		}
+
+		public void setSeccompProfile(SeccompProfile seccompProfile) {
+			this.seccompProfile = seccompProfile;
+		}
+	}
+
+	/**
+	 * Defines a pod seccomp profile settings.
+	 */
+	public static class SeccompProfile {
+
+		/**
+		 * Type of seccomp profile.
+		 */
+		private String type;
+
+		/**
+		 * Path of the pre-configured profile on the node, relative to the kubelet's configured Seccomp profile location, only valid when type is "Localhost".
+		 */
+		private String localhostProfile;
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		public String getLocalhostProfile() {
+			return localhostProfile;
+		}
+
+		public void setLocalhostProfile(String localhostProfile) {
+			this.localhostProfile = localhostProfile;
 		}
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -337,12 +337,24 @@ public class KubernetesDeployerProperties {
 	}
 
 	public static class PodSecurityContext {
+		/**
+		 * The numeric user ID to run pod container processes under
+		 */
 		private Long runAsUser;
 
+		/**
+		 * The numeric group ID for the volumes of the pod
+		 */
 		private Long fsGroup;
 
+		/**
+		 * The numeric group IDs applied to the pod container processes, in addition to the container's primary group ID
+		 */
 		private Long[] supplementalGroups;
 
+		/**
+		 * The seccomp options to use for the pod containers
+		 */
 		private SeccompProfile seccompProfile;
 
 		public void setRunAsUser(Long runAsUser) {
@@ -407,6 +419,34 @@ public class KubernetesDeployerProperties {
 
 		public void setLocalhostProfile(String localhostProfile) {
 			this.localhostProfile = localhostProfile;
+		}
+	}
+
+	public static class ContainerSecurityContext {
+		/**
+		 * Whether a process can gain more privileges than its parent process
+		 */
+		private boolean allowPrivilegeEscalation;
+
+		/**
+		 * Mounts the container's root filesystem as read-only
+		 */
+		private boolean readOnlyRootFilesystem;
+
+		public void setAllowPrivilegeEscalation(boolean allowPrivilegeEscalation) {
+			this.allowPrivilegeEscalation = allowPrivilegeEscalation;
+		}
+
+		public boolean isAllowPrivilegeEscalation() {
+			return allowPrivilegeEscalation;
+		}
+
+		public void setReadOnlyRootFilesystem(boolean readOnlyRootFilesystem) {
+			this.readOnlyRootFilesystem = readOnlyRootFilesystem;
+		}
+
+		public boolean isReadOnlyRootFilesystem() {
+			return readOnlyRootFilesystem;
 		}
 	}
 
@@ -865,6 +905,11 @@ public class KubernetesDeployerProperties {
 	 * The security context to apply to created pod's.
 	 */
 	private PodSecurityContext podSecurityContext;
+
+	/**
+	 * The security context to apply to created pod's main container.
+	 */
+	private ContainerSecurityContext containerSecurityContext;
 
 	/**
 	 * The node affinity rules to apply.
@@ -1489,6 +1534,14 @@ public class KubernetesDeployerProperties {
 
 	public PodSecurityContext getPodSecurityContext() {
 		return podSecurityContext;
+	}
+
+	public void setContainerSecurityContext(ContainerSecurityContext containerSecurityContext) {
+		this.containerSecurityContext = containerSecurityContext;
+	}
+
+	public ContainerSecurityContext getContainerSecurityContext() {
+		return containerSecurityContext;
 	}
 
 	public NodeAffinity getNodeAffinity() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -38,6 +38,7 @@ import io.fabric8.kubernetes.api.model.PodAffinity;
 import io.fabric8.kubernetes.api.model.PodAffinityTerm;
 import io.fabric8.kubernetes.api.model.PodAntiAffinity;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PreferredSchedulingTerm;
 import io.fabric8.kubernetes.api.model.SeccompProfile;
@@ -77,7 +78,6 @@ public class KubernetesAppDeployerTests {
 
 	private DeploymentPropertiesResolver deploymentPropertiesResolver = new DeploymentPropertiesResolver(
 			KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX, new KubernetesDeployerProperties());
-
 
 	@Test
 	public void deployWithVolumesOnly() throws Exception {
@@ -1243,196 +1243,178 @@ public class KubernetesAppDeployerTests {
 	}
 
 	@Test
-	public void testPodSecurityContextProperty() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
+	public void testPodSecurityContextPropertyAllFields() {
+		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+		Map<String, String> deploymentProps = new HashMap<>();
+		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withRunAsUser(65534L)
+				.withFsGroup(65534L)
+				.withSupplementalGroups(65534L, 65535L)
+				.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
+				.build();
 
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
 	}
 
 	@Test
 	public void testPodSecurityContextPropertyUIDOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
+		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+		Map<String, String> deploymentProps = new HashMap<>();
+		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withRunAsUser(65534L)
+				.build();
 
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
 	}
 
 	@Test
 	public void testPodSecurityContextPropertyFsGroupOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
+		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+		Map<String, String> deploymentProps = new HashMap<>();
+		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withFsGroup(65534L)
+				.build();
 
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
 	}
 
 	@Test
 	public void testPodSecurityContextPropertySupplementalGroupsOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
+		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+		Map<String, String> deploymentProps = new HashMap<>();
+		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withSupplementalGroups(65534L, 65535L)
+				.build();
 
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L }));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
 	}
 
 	@Test
 	public void testPodSecurityContextPropertySeccompProfileOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
+		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+		Map<String, String> deploymentProps = new HashMap<>();
+		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
+				.build();
 
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
-				.isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
 	}
 
 	@Test
 	public void testPodSecurityContextPropertyFromYaml() throws Exception {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
+		KubernetesDeployerProperties globalDeployerProps = bindDeployerProperties();
+		Map<String, String> deploymentProps = new HashMap<>();
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withRunAsUser(65534L)
+				.withFsGroup(65534L)
+				.withSupplementalGroups(65534L, 65535L)
+				.withSeccompProfile(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"))
+				.build();
 
-		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"));
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
 	}
 
 	@Test
 	public void testPodSecurityContextGlobalProperty() {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
-
-		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("profile.json");
-
+		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
 		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
 		securityContext.setFsGroup(65534L);
 		securityContext.setRunAsUser(65534L);
 		securityContext.setSupplementalGroups(new Long[]{65534L});
+		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+		seccompProfile.setType("Localhost");
+		seccompProfile.setLocalhostProfile("profile.json");
 		securityContext.setSeccompProfile(seccompProfile);
+		globalDeployerProps.setPodSecurityContext(securityContext);
 
-		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
+		Map<String, String> deploymentProps = Collections.emptyMap();
 
-		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withRunAsUser(65534L)
+				.withFsGroup(65534L)
+				.withSupplementalGroups(65534L)
+				.withSeccompProfile(new SeccompProfile("profile.json", "Localhost"))
+				.build();
 
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("profile.json", "Localhost"));
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
 	}
 
 	@Test
 	public void testPodSecurityContextPropertyOverrideGlobal() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("sec/default-allow.json");
-
+		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
 		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
 		securityContext.setFsGroup(1000L);
 		securityContext.setRunAsUser(1000L);
-		securityContext.setSupplementalGroups(new Long[] {1000L});
+		securityContext.setSupplementalGroups(new Long[]{1000L});
+		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+		seccompProfile.setType("Localhost");
+		seccompProfile.setLocalhostProfile("sec/default-allow.json");
 		securityContext.setSeccompProfile(seccompProfile);
+		globalDeployerProps.setPodSecurityContext(securityContext);
 
-		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
+		Map<String, String> deploymentProps = new HashMap<>();
+		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
 
-		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+				.withRunAsUser(65534L)
+				.withFsGroup(65534L)
+				.withSupplementalGroups(65534L, 65535L)
+				.withSeccompProfile(new SeccompProfile("sec/custom-allow.json", "Localhost"))
+				.build();
 
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
 
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+		assertThat(actualPodSecurityContext)
+				.isNotNull()
+				.isEqualTo(expectedPodSecurityContext);
+	}
 
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups")
-				.isEqualTo(Arrays.asList(new Long[] {65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
-				.isEqualTo(new SeccompProfile("sec/custom-allow.json", "Localhost"));
+	private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
+		KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
+		return deployer.createPodSpec(appDeploymentRequest);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -825,27 +825,6 @@ public class KubernetesAppDeployerTests {
 	}
 
 	@Test
-	public void testPodSecurityContextProperty() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
-	}
-
-	@Test
 	public void testNodeAffinityProperty() {
 		Map<String, String> props = new HashMap<>();
 		props.put("spring.cloud.deployer.kubernetes.affinity.nodeAffinity",
@@ -945,38 +924,6 @@ public class KubernetesAppDeployerTests {
 		assertThat(podAntiAffinity).as("Pod anti-affinity should not be null").isNotNull();
 		assertThat(podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
 		assertThat(podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
-	}
-
-	@Test
-	public void testPodSecurityContextGlobalProperty() {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
-
-		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("profile.json");
-
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(65534L);
-		securityContext.setRunAsUser(65534L);
-		securityContext.setSupplementalGroups(new Long[]{65534L});
-		securityContext.setSeccompProfile(seccompProfile);
-
-		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
-
-		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("profile.json", "Localhost"));
 	}
 
 	@Test
@@ -1100,24 +1047,6 @@ public class KubernetesAppDeployerTests {
 	}
 
 	@Test
-	public void testPodSecurityContextFromYaml() throws Exception {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
-
-		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"));
-	}
-
-	@Test
 	public void testNodeAffinityFromYaml() throws Exception {
 		AppDefinition definition = new AppDefinition("app-test", null);
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
@@ -1157,128 +1086,6 @@ public class KubernetesAppDeployerTests {
 		assertThat(podAntiAffinity).as("Pod anti-affinity should not be null").isNotNull();
 		assertThat(podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
 		assertThat(podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
-	}
-
-	@Test
-	public void testPodSecurityContextUIDOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
-	}
-
-	@Test
-	public void testPodSecurityContextFsGroupOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
-	}
-
-    @Test
-    public void testPodSecurityContextSupplementalGroupsOnly() {
-        Map<String, String> props = new HashMap<>();
-        props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
-
-        AppDefinition definition = new AppDefinition("app-test", null);
-        AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-        deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-        PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-        PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-        assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-        assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-        assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-        assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L }));
-        assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
-    }
-
-	@Test
-	public void testPodSecurityContextSeccompProfileOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
-				.isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyOverrideGlobal() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("sec/default-allow.json");
-
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(1000L);
-		securityContext.setRunAsUser(1000L);
-		securityContext.setSupplementalGroups(new Long[] {1000L});
-		securityContext.setSeccompProfile(seccompProfile);
-
-		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
-
-		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups")
-				.isEqualTo(Arrays.asList(new Long[] {65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
-				.isEqualTo(new SeccompProfile("sec/custom-allow.json", "Localhost"));
 	}
 
 	@Test
@@ -1436,6 +1243,199 @@ public class KubernetesAppDeployerTests {
 	}
 
 	@Test
+	public void testPodSecurityContextProperty() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyUIDOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyFsGroupOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+	}
+
+	@Test
+	public void testPodSecurityContextPropertySupplementalGroupsOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L }));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+	}
+
+	@Test
+	public void testPodSecurityContextPropertySeccompProfileOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
+				.isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyFromYaml() throws Exception {
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
+
+		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"));
+	}
+
+	@Test
+	public void testPodSecurityContextGlobalProperty() {
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
+
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+
+		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+		seccompProfile.setType("Localhost");
+		seccompProfile.setLocalhostProfile("profile.json");
+
+		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+		securityContext.setFsGroup(65534L);
+		securityContext.setRunAsUser(65534L);
+		securityContext.setSupplementalGroups(new Long[]{65534L});
+		securityContext.setSeccompProfile(seccompProfile);
+
+		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
+
+		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("profile.json", "Localhost"));
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyOverrideGlobal() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+
+		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+		seccompProfile.setType("Localhost");
+		seccompProfile.setLocalhostProfile("sec/default-allow.json");
+
+		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+		securityContext.setFsGroup(1000L);
+		securityContext.setRunAsUser(1000L);
+		securityContext.setSupplementalGroups(new Long[] {1000L});
+		securityContext.setSeccompProfile(seccompProfile);
+
+		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
+
+		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups")
+				.isEqualTo(Arrays.asList(new Long[] {65534L, 65535L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
+				.isEqualTo(new SeccompProfile("sec/custom-allow.json", "Localhost"));
+	}
+
+	@Test
 	public void testWithLifecyclePostStart() {
 		Map<String, String> props = new HashMap<>();
 		props.put("spring.cloud.deployer.kubernetes.lifecycle.postStart.exec.command",
@@ -1504,7 +1504,6 @@ public class KubernetesAppDeployerTests {
 		assertThat(podSpec.getContainers().get(0).getLifecycle().getPreStop().getExec().getCommand())
 				.containsExactlyInAnyOrder("echo", "preStop");
 	}
-
 
 	@Test
 	public void testLifecyclePrestopOverridesGlobalPrestop() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -46,6 +46,8 @@ import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
@@ -72,6 +74,7 @@ import static org.assertj.core.api.Assertions.entry;
  * @author Enrique Medina Montenegro
  * @author Chris Bono
  */
+@DisplayName("KubernetesAppDeployer")
 public class KubernetesAppDeployerTests {
 
 	private KubernetesAppDeployer deployer;
@@ -1242,179 +1245,188 @@ public class KubernetesAppDeployerTests {
 		assertThat(podAntiAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
-	@Test
-	public void testPodSecurityContextPropertyAllFields() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L, 65535L)
-				.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyUIDOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyFsGroupOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withFsGroup(65534L)
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertySupplementalGroupsOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withSupplementalGroups(65534L, 65535L)
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertySeccompProfileOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyFromYaml() throws Exception {
-		KubernetesDeployerProperties globalDeployerProps = bindDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L, 65535L)
-				.withSeccompProfile(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextGlobalProperty() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(65534L);
-		securityContext.setRunAsUser(65534L);
-		securityContext.setSupplementalGroups(new Long[]{65534L});
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("profile.json");
-		securityContext.setSeccompProfile(seccompProfile);
-		globalDeployerProps.setPodSecurityContext(securityContext);
-
-		Map<String, String> deploymentProps = Collections.emptyMap();
-
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L)
-				.withSeccompProfile(new SeccompProfile("profile.json", "Localhost"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyOverrideGlobal() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(1000L);
-		securityContext.setRunAsUser(1000L);
-		securityContext.setSupplementalGroups(new Long[]{1000L});
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("sec/default-allow.json");
-		securityContext.setSeccompProfile(seccompProfile);
-		globalDeployerProps.setPodSecurityContext(securityContext);
-
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
-
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L, 65535L)
-				.withSeccompProfile(new SeccompProfile("sec/custom-allow.json", "Localhost"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
-		KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
-		return deployer.createPodSpec(appDeploymentRequest);
+	@Nested 
+	@DisplayName("creates pod spec with pod security context")
+	class CreatePodSpecWithPodSecurityContext {
+	
+		@Test
+		@DisplayName("created from deployment property with all fields")
+		void createdFromDeploymentPropertyWithAllFields() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L, 65535L)
+					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with runAsUser only")
+		void createdFromDeploymentPropertyWithRunAsUserOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with fsGroup only")
+		void createdFromDeploymentPropertyWithFsGroupOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withFsGroup(65534L)
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with supplementalGroups only")
+		void createdFromDeploymentPropertyWithSupplementalGroupsOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withSupplementalGroups(65534L, 65535L)
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with seccompProfile only")
+		void createdFromDeploymentPropertyWithSeccompProfileOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from global deployer property sourced from yaml")
+		void createdFromGlobalDeployerPropertySourcedFromYaml() throws Exception {
+			KubernetesDeployerProperties globalDeployerProps = bindDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L, 65535L)
+					.withSeccompProfile(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from global deployer property")
+		void createdFromGlobalDeployerProperty() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+			securityContext.setFsGroup(65534L);
+			securityContext.setRunAsUser(65534L);
+			securityContext.setSupplementalGroups(new Long[]{65534L});
+			KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+			seccompProfile.setType("Localhost");
+			seccompProfile.setLocalhostProfile("profile.json");
+			securityContext.setSeccompProfile(seccompProfile);
+			globalDeployerProps.setPodSecurityContext(securityContext);
+			Map<String, String> deploymentProps = Collections.emptyMap();
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L)
+					.withSeccompProfile(new SeccompProfile("profile.json", "Localhost"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property overrriding global deployer property")
+		void createdFromDeploymentPropertyOverridingGlobalDeployerProperty() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+			securityContext.setFsGroup(1000L);
+			securityContext.setRunAsUser(1000L);
+			securityContext.setSupplementalGroups(new Long[]{1000L});
+			KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+			seccompProfile.setType("Localhost");
+			seccompProfile.setLocalhostProfile("sec/default-allow.json");
+			securityContext.setSeccompProfile(seccompProfile);
+			globalDeployerProps.setPodSecurityContext(securityContext);
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L, 65535L)
+					.withSeccompProfile(new SeccompProfile("sec/custom-allow.json", "Localhost"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
+			AppDefinition definition = new AppDefinition("app-test", null);
+			AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
+			KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
+			return deployer.createPodSpec(appDeploymentRequest);
+		}
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -1261,13 +1261,7 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L, 65535L)
 					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1279,13 +1273,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withRunAsUser(65534L)
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1297,13 +1285,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withFsGroup(65534L)
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1315,13 +1297,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withSupplementalGroups(65534L, 65535L)
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1333,13 +1309,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1353,13 +1323,7 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L, 65535L)
 					.withSeccompProfile(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1382,13 +1346,7 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L)
 					.withSeccompProfile(new SeccompProfile("profile.json", "Localhost"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1412,15 +1370,21 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L, 65535L)
 					.withSeccompProfile(new SeccompProfile("sec/custom-allow.json", "Localhost"))
 					.build();
-	
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
+		}
+
+		private void assertThatDeployerCreatesPodSpecWithPodSecurityContext(
+				KubernetesDeployerProperties globalDeployerProps,
+				Map<String, String> deploymentProps,
+				PodSecurityContext expectedPodSecurityContext
+		) {
 			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
 			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
 			assertThat(actualPodSecurityContext)
 					.isNotNull()
 					.isEqualTo(expectedPodSecurityContext);
 		}
-	
+
 		private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
 			AppDefinition definition = new AppDefinition("app-test", null);
 			AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);

--- a/src/test/resources/dataflow-server-containerSecurityContext.yml
+++ b/src/test/resources/dataflow-server-containerSecurityContext.yml
@@ -1,0 +1,4 @@
+# spring.cloud.deployer.kubernetes.containerSecurityContext:
+containerSecurityContext:
+  allowPrivilegeEscalation: true
+  readOnlyRootFilesystem: false

--- a/src/test/resources/dataflow-server-podsecuritycontext.yml
+++ b/src/test/resources/dataflow-server-podsecuritycontext.yml
@@ -3,3 +3,6 @@ podSecurityContext:
   runAsUser: 65534
   fsGroup: 65534
   supplementalGroups: [65534,65535]
+  seccompProfile:
+    type: Localhost
+    localhostProfile: my-profiles/profile-allow.json


### PR DESCRIPTION

This builds upon https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/pull/472 and does the following:

### Adds support for configuring the security context on the main container

#### Question 1
I only apply the context to the main container. Should we add this to the initContainer as well? There is no need to do anything special for additional containers as the only mechanism to configure those is via full yaml - consumers can simply add the security context in that yaml if need be. 

#### Question 2
Should we support more than these 2 requested properties? I know we do not support all available properties on the pod security context either. On one hand, adding more properties increases code to maintain. On the other hand, adding more properties gives users more options. 



### Refactors KubernetesAppDeployerTests as follows:
- Moved the pod and container security related tests into their own @Nested tests. 
- Simplified the assertions to use actual/expected object equality rather than individual property asserts


**Motivation:** 
The `KubernetesAppDeployerTests` has grown quite large and it is a challenge for a newbie (me) to grok all of whats going on in there. I leveraged `@Nested` to group the pod and container security context tests. I really love the output that `@Nested` produces in IntelliJ as well (see below)


<img width="1127" alt="nested-test-output" src="https://user-images.githubusercontent.com/28907971/146968529-21dc0b3f-2f11-4796-a2cb-c3e4fa4f460d.png">


#### Question 3
I am curious to what the team thinks on this test as a whole. Should it be:

1. left as-is?
2. split into separate `KubernetesAppDeployer<tested-area-goes-here>Tests`?
3. apply @Nessted to other areas of the test as well? 


## TODO 
- [ ] Docs to be updates shortly in counterpart pull request to `spring-cloud-dataflow-docs`.

